### PR TITLE
Fix docs for CodonOptimize's TaxID species in Genbank API

### DIFF
--- a/docs/genbank/genbank_api.rst
+++ b/docs/genbank/genbank_api.rst
@@ -217,7 +217,7 @@ As you noticed we used species names in these examples. See
 for species that can be referred to by name. This includes ``b_subtilis``,
 ``c_elegans``, ``d_melanogaster``, ``e_coli``, ``g_gallus``, ``h_sapiens``,
 ``m_musculus``, ``s_cerevisiae``. You can also use a TaxID to refer to a species,
-e.g. ``species=1423`` at which case the codon frequencies will be downloaded from
+e.g. ``species='1423'`` in which case the codon frequencies will be downloaded from
 the `Kazusa codon usage database <https://www.kazusa.or.jp/codon/>`_ (assuming it
 isn't down!)
 


### PR DESCRIPTION
Without quotes, the species is parsed as `int` and the `optimize` function raises the following exception:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/simonepignotti/.conda/envs/dnachisel/lib/python3.7/site-packages/dnachisel/DnaOptimizationProblem/DnaOptimizationProblem.py", line 258, in optimize_with_report
    self.optimize()
  File "/Users/simonepignotti/.conda/envs/dnachisel/lib/python3.7/site-packages/dnachisel/DnaOptimizationProblem/mixins/ObjectivesMaximizerMixin.py", line 215, in optimize
    objective=objectives, bar_message=lambda o: str(o)
  File "/Users/simonepignotti/.conda/envs/dnachisel/lib/python3.7/site-packages/proglog/proglog.py", line 199, in new_iterable
    self(**{bar + '__message': bar_message(it)})
  File "/Users/simonepignotti/.conda/envs/dnachisel/lib/python3.7/site-packages/dnachisel/DnaOptimizationProblem/mixins/ObjectivesMaximizerMixin.py", line 215, in <lambda>
    objective=objectives, bar_message=lambda o: str(o)
  File "/Users/simonepignotti/.conda/envs/dnachisel/lib/python3.7/site-packages/dnachisel/Specification/Specification.py", line 190, in __str__
    return self.label()
  File "/Users/simonepignotti/.conda/envs/dnachisel/lib/python3.7/site-packages/dnachisel/Specification/Specification.py", line 167, in label
    for p in params
TypeError: sequence item 0: expected str instance, int found
```