### PR TITLE
Fix a referenced-before-assignment bug in UniquifyAllKmers

### DIFF
--- a/dnachisel/builtin_specifications/UniquifyAllKmers.py
+++ b/dnachisel/builtin_specifications/UniquifyAllKmers.py
@@ -38,9 +38,9 @@ def get_kmer_extractor_cached(sequence, include_reverse_complement=True, k=1):
     This globally cached method enables much faster computations when
     several UniquifyAllKmers functions with equal k are used. 
     """
+    L = len(sequence)
     if include_reverse_complement:
         rev_comp_sequence = reverse_complement(sequence)
-        L = len(sequence)
 
         @lru_cache(maxsize=L)
         def extract_kmer(i):


### PR DESCRIPTION
The following code
```python
from dnachisel import *
sequence = random_dna_sequence(50000)
constraint = UniquifyAllKmers(10, include_reverse_complement=False)
problem = DnaOptimizationProblem(sequence, constraints=[constraint])
print(problem.constraints_text_summary())
```
produces the following error
```
  File "/dnachisel/lib/python3.8/site-packages/dnachisel/builtin_specifications/UniquifyAllKmers.py", line 53, in get_kmer_extractor_cached
    @lru_cache(maxsize=L)
UnboundLocalError: local variable 'L' referenced before assignment
```

This only happens when using `UniquifyAllKmers` with `include_reverse_complement=False`.