### PR TITLE
Add comparison operators to Location object

### DIFF
--- a/dnachisel/Location.py
+++ b/dnachisel/Location.py
@@ -5,6 +5,8 @@ a subsequence from a sequence, etc.
 """
 from functools import total_ordering
 
+from Bio.SeqFeature import FeatureLocation, SeqFeature
+
 from .biotools import reverse_complement
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 
@@ -98,7 +100,7 @@ class Location:
     def __eq__(self, other):
         """Equal to."""
         return self.to_tuple() == other.to_tuple()
-    
+
     def __lt__(self, other):
         """Lower than."""
         return self.to_tuple() < other.to_tuple()
@@ -121,6 +123,9 @@ class Location:
     def __len__(self):
         """Size of the location."""
         return self.end - self.start
+
+    def __hash__(self):
+        return hash((self.start, self.end, self.strand))
 
     @staticmethod
     def merge_overlapping_locations(locations):

--- a/dnachisel/Location.py
+++ b/dnachisel/Location.py
@@ -125,7 +125,7 @@ class Location:
         return self.end - self.start
 
     def __hash__(self):
-        return hash((self.start, self.end, self.strand))
+        return hash(self.to_tuple())
 
     @staticmethod
     def merge_overlapping_locations(locations):

--- a/tests/test_Location.py
+++ b/tests/test_Location.py
@@ -49,3 +49,20 @@ def test___ge__(location_1: Location, location_2: Location, expected_result: boo
 )
 def test___lt__(location_1: Location, location_2: Location, expected_result: bool):
     assert (location_1 < location_2) == expected_result
+
+@pytest.mark.parametrize("location_1,location_2,expected_result", [
+        (Location(0, 1), Location(0, 1), True),
+        (Location(0, 1), Location(0, 1, 0), True),
+        (Location(0, 1, 0), Location(0, 1), True),
+        (Location(0, 1), Location(1, 1), False),
+        (Location(1, 0), Location(0, 1), False),
+        (Location(1, 0, 1), Location(1, 0), False),
+        (Location(0, 1), Location(0, 1, 1), False),
+        (Location(0, 1, 1), Location(0, 1), False),
+        (Location(0, 1, 1), Location(0, 1, 1), True),
+        (Location(0, 1, 0), Location(0, 1, 0), True),
+        (Location(0, 1), Location(1, 0), False),
+    ]
+)
+def test__hash__(location_1, location_2, expected_result):
+    assert (hash(location_1) == hash(location_2)) == expected_result


### PR DESCRIPTION
I was writing some unit tests for a tool I wrote which uses DnaChisel. I wanted to assert equality between some Location objects, but found that currently Location only supports `<` and it looks like it tries to support `>=`.

This PR does the following:
* Adds in two missing dependencies for DnaChisel that I discovered when I tried to run the DnaChisel test suite. (Feel free to let me know if I missed them and I can remove this part from the PR)
* Adds an `__eq__` method to the `Location` class so that we can test for equality now.
* Removes the `__geq__` method - I believe the correct syntax would have been `__ge__`. However we don't need this method now because I also:
* Added the `total_ordering` decorator to the definition of the `Location` class. This decorator will automatically create all comparison operators as long as the class has a definition of `__eq__` and one other comparison - in this case we also have `__lt__`
* Added some unit tests for Location to check that the `==`, `>=` and `<` comparisons all work.
