### PR TITLE
All builtin specifications now correctly recognize `boost` parameter.

### DIFF
--- a/dnachisel/builtin_specifications/AllowPrimer.py
+++ b/dnachisel/builtin_specifications/AllowPrimer.py
@@ -62,6 +62,7 @@ class AllowPrimer(SpecificationSet):
         avoid_heterodim_with=None,
         max_heterodim_tm=5,
         avoided_repeats=((2, 5), (3, 4), (4, 3)),
+        boost=1.0,
     ):
         location = Location.from_data(location)
         specs = {
@@ -86,3 +87,4 @@ class AllowPrimer(SpecificationSet):
                 location=location,
             )
         self.register_specifications(specs)
+        self.boost = boost

--- a/dnachisel/builtin_specifications/AllowPrimer.py
+++ b/dnachisel/builtin_specifications/AllowPrimer.py
@@ -67,15 +67,15 @@ class AllowPrimer(SpecificationSet):
         location = Location.from_data(location)
         specs = {
             "unique_sequence": UniquifyAllKmers(
-                k=max_homology_length, location=location
+                k=max_homology_length, location=location, boost=boost
             ),
             "melting_temperature": EnforceMeltingTemperature(
-                mini=tmin, maxi=tmax, location=location
+                mini=tmin, maxi=tmax, location=location, boost=boost
             ),
             **{
                 "repeats_%d_%d"
                 % (k, n): AvoidPattern(
-                    RepeatedKmerPattern(k, n), location=location
+                    RepeatedKmerPattern(k, n), location=location, boost=boost
                 )
                 for (k, n) in avoided_repeats
             },
@@ -85,6 +85,7 @@ class AllowPrimer(SpecificationSet):
                 other_primers_sequences=avoid_heterodim_with,
                 tmax=max_heterodim_tm,
                 location=location,
+                boost=boost,
             )
         self.register_specifications(specs)
         self.boost = boost

--- a/dnachisel/builtin_specifications/AvoidBlastMatches.py
+++ b/dnachisel/builtin_specifications/AvoidBlastMatches.py
@@ -55,6 +55,7 @@ class AvoidBlastMatches(Specification):
         e_value=1e80,
         culling_limit=1,
         location=None,
+        boost=1.0,
     ):
         """Initialize."""
         self.blast_db = blast_db
@@ -68,6 +69,7 @@ class AvoidBlastMatches(Specification):
         self.e_value = e_value
         self.ungapped = ungapped
         self.culling_limit = culling_limit
+        self.boost = boost
 
     def initialized_on_problem(self, problem, role=None):
         return self._copy_with_full_span_if_no_location(problem)

--- a/dnachisel/builtin_specifications/AvoidHeterodimerization.py
+++ b/dnachisel/builtin_specifications/AvoidHeterodimerization.py
@@ -36,6 +36,7 @@ class AvoidHeterodimerization(Specification):
         self.other_primers_sequences = other_primers_sequences
         self.tmax = tmax
         self.location = location
+        self.boost = boost
 
     def initialized_on_problem(self, problem, role=None):
         return self._copy_with_full_span_if_no_location(problem)

--- a/dnachisel/builtin_specifications/SequenceLengthBounds.py
+++ b/dnachisel/builtin_specifications/SequenceLengthBounds.py
@@ -20,9 +20,10 @@ class SequenceLengthBounds(Specification):
     """
     best_possible_score = 0
 
-    def __init__(self, min_length=0, max_length=None):
+    def __init__(self, min_length=0, max_length=None, boost=1.0):
         self.min_length = min_length
         self.max_length = max_length
+        self.boost = boost
 
     def evaluate(self, problem):
         """Return 0 if the sequence length is between the bounds, else -1"""

--- a/dnachisel/builtin_specifications/UniquifyAllKmers.py
+++ b/dnachisel/builtin_specifications/UniquifyAllKmers.py
@@ -137,7 +137,7 @@ class UniquifyAllKmers(Specification):
             reference = Location.from_tuple(reference)
         self.reference = reference
         self.include_reverse_complement = include_reverse_complement
-        self.boost = 1.0
+        self.boost = boost
         self.localization_data = localization_data
 
     def initialized_on_problem(self, problem, role="constraint"):


### PR DESCRIPTION
Hello!

I've found out that some of the builtin specifications either don't recognize `boost` argument and some do, but set it incorrectly. In particular:

- AllowPrimer (as discussed in #71 ), AvoidBlastMatches and SequenceLengthBounds did not accept the boost argument (the omitting of `boost` in SequenceLengthBounds might have been intentional, but added it for consistency).
- AvoidHeterodimenzation accepted the parameter, but did not set it.
- UniquifyAllKmers accepted the parameter, but set it to `1.0` regardless.

This PR fixes the aforementioned issues.
And possibly closes #71 .

Best,
Ondrej