### PR TITLE
GCContent module is compatible with numpy 2.1.0.

### DIFF
--- a/dnachisel/builtin_specifications/EnforceGCContent.py
+++ b/dnachisel/builtin_specifications/EnforceGCContent.py
@@ -100,6 +100,9 @@ class EnforceGCContent(Specification):
         wstart, wend = self.location.start, self.location.end
         sequence = self.location.extract_sequence(problem.sequence)
         gc = gc_content(sequence, window_size=self.window)
+        # Ensure that GC is not a scalar.
+        if len(gc.shape) == 0:
+            gc = np.reshape(gc, (1,))
         breaches = np.maximum(0, self.mini - gc) + np.maximum(
             0, gc - self.maxi
         )


### PR DESCRIPTION
Hello,

This PR fixes #83 .

The compatibility issue comes from the fact that the `gc_content` function when not given a window size returns a scalar.
To ensure full backwards compatibility, I fixed this on the level of the caller to `gc_content`.

Best,
Ondrej