### PR TITLE
Update to be compatible with numpy 2.1

### DIFF
--- a/dnachisel/builtin_specifications/EnforceGCContent.py
+++ b/dnachisel/builtin_specifications/EnforceGCContent.py
@@ -100,11 +100,13 @@ class EnforceGCContent(Specification):
         wstart, wend = self.location.start, self.location.end
         sequence = self.location.extract_sequence(problem.sequence)
         gc = gc_content(sequence, window_size=self.window)
-        breaches = np.maximum(0, self.mini - gc) + np.maximum(
-            0, gc - self.maxi
+        breaches = np.atleast_1d(
+            np.maximum(0, self.mini - gc) + np.maximum(
+                0, gc - self.maxi
+            )
         )
         score = -breaches.sum()
-        breaches_starts = wstart + (np.atleast_1d(breaches) > 0).nonzero()[0]
+        breaches_starts = wstart + (breaches > 0).nonzero()[0]
 
         if len(breaches_starts) == 0:
             breaches_locations = []

--- a/dnachisel/builtin_specifications/EnforceGCContent.py
+++ b/dnachisel/builtin_specifications/EnforceGCContent.py
@@ -104,7 +104,7 @@ class EnforceGCContent(Specification):
             0, gc - self.maxi
         )
         score = -breaches.sum()
-        breaches_starts = wstart + (breaches > 0).nonzero()[0]
+        breaches_starts = wstart + (np.atleast_1d(breaches) > 0).nonzero()[0]
 
         if len(breaches_starts) == 0:
             breaches_locations = []


### PR DESCRIPTION
With numpy >= 2.1, there is an error triggered in `EnforceGCContent`, indicating that calling "nonzero on 0d arrays" is not permitted. 

This PR updates the code to be compatible with numpy >= 2.1 (and still works for older versions).

Related to this issue:
https://github.com/Edinburgh-Genome-Foundry/DnaChisel/issues/83

Similar in spirit to https://github.com/Edinburgh-Genome-Foundry/DnaChisel/pull/84 (didn't see that PR when I originally issued this one.)