### PR TITLE
MAINT: adapt MotifPssmPattern to modern biopython

### DIFF
--- a/dnachisel/SequencePattern/MotifPssmPattern.py
+++ b/dnachisel/SequencePattern/MotifPssmPattern.py
@@ -16,7 +16,7 @@ class MotifPssmPattern(SequencePattern):
     ----------
 
     pssm
-      A Bio.Align.AlignInfo.PSSM object.
+      A `Bio.motifs.Motif` object.
 
     threshold
      locations of the sequence with a PSSM score above this value will be
@@ -32,6 +32,10 @@ class MotifPssmPattern(SequencePattern):
     def __init__(
         self, pssm, threshold=None, relative_threshold=None,
     ):
+        if not isinstance(pssm, Bio.motifs.Motif):
+            raise ValueError(
+                f"Expected PSSM type of `Bio.motifs.Motif`, but {type(pssm)} was passed"
+            )
         self.name = pssm.name
         self.pssm = pssm.pssm
         if relative_threshold is not None:
@@ -108,8 +112,8 @@ class MotifPssmPattern(SequencePattern):
         sequences = [Seq(s) for s in sequences]
         motif = motifs.create(sequences)
         cls.apply_pseudocounts(motif, pseudocounts)
-        pssm = PSSM(motif.pssm)
-        pssm.name = name
+        motif.name = name
+        pssm = motif
         return MotifPssmPattern(
             pssm=pssm, threshold=threshold, relative_threshold=relative_threshold,
         )

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -37,3 +37,12 @@ def test_pssm_pattern_from_file(
     )
     assert len(multiple_patterns) == 2
     assert all([isinstance(p, MotifPssmPattern) for p in multiple_patterns])
+
+
+def test_pssm_from_sequences():
+    seqs = ['ACGT', 'ACCT', 'AAGT']
+    motif_name = "test motif"
+    pat = MotifPssmPattern.from_sequences(seqs, name=motif_name, relative_threshold=0.9)
+    assert isinstance(pat, MotifPssmPattern)
+    assert len(pat.find_matches_in_string("ACATACGTACAC")) == 1
+    assert len(pat.find_matches_in_string("ACATAATTACAC")) == 0


### PR DESCRIPTION
Hi,

Since biopython v1.82, `Bio.Align.AlignInfo.PSSM` class is deprecated (there's a v1.84 biopython out there already) and `Bio.motifs.Motif` is favored. Prior to this PR, the mentioned deprecated class serves as the input of the MotifPssmPattern constructor. However, the two helper class methods that load pssm files or alignment use Biopython's create/parse methods that return the recommended `Bio.motifs.Motif` objects. For example, the following code fails with biopython>=1.82:
```python
from dnachisel import MotifPssmPattern

seqs = ['ACGT', 'ACCT', 'AAGT']
motif_name = "test motif"
MotifPssmPattern.from_sequences(seqs, name=motif_name, relative_threshold=0.9)
```

The result is the following error: ```AttributeError: 'PSSM' object has no attribute 'length'```

The proposed PR adds a test case, changes the documented input class to `MotifPssmPattern` to the recommended `Bio.motifs.Motif`, validates the input as such, and fixes the motif loading logic of `from_sequences` according to the changes in newer biopython.

The proposed change suggests setting a minimally supported biopython version, but this seems beyond the scope of this PR. 