### PR TITLE
Fix "unkown Bio" error in MotifPssmPattern

### DIFF
--- a/dnachisel/SequencePattern/MotifPssmPattern.py
+++ b/dnachisel/SequencePattern/MotifPssmPattern.py
@@ -30,12 +30,7 @@ class MotifPssmPattern(SequencePattern):
       sequence(s) with the absolute highest possible score".
     """
 
-    def __init__(
-        self,
-        pssm,
-        threshold=None,
-        relative_threshold=None,
-    ):
+    def __init__(self, pssm, threshold=None, relative_threshold=None):
         if not isinstance(pssm, Bio.motifs.Motif):
             raise ValueError(
                 f"Expected PSSM type of `Bio.motifs.Motif`, but {type(pssm)} was passed"
@@ -74,9 +69,7 @@ class MotifPssmPattern(SequencePattern):
         #     sequence, threshold=self.threshold, both=False
         # )
         indices = find_pssm_matches_with_numpy(
-            pssm_matrix=self.pssm_matrix,
-            sequence=sequence,
-            threshold=self.threshold,
+            pssm_matrix=self.pssm_matrix, sequence=sequence, threshold=self.threshold
         )
         return [(i, i + self.size, 1) for i in indices]
 
@@ -121,9 +114,7 @@ class MotifPssmPattern(SequencePattern):
         motif.name = name
         pssm = motif
         return MotifPssmPattern(
-            pssm=pssm,
-            threshold=threshold,
-            relative_threshold=relative_threshold,
+            pssm=pssm, threshold=threshold, relative_threshold=relative_threshold
         )
 
     @classmethod
@@ -172,9 +163,7 @@ class MotifPssmPattern(SequencePattern):
 
         return [
             MotifPssmPattern(
-                pssm,
-                threshold=threshold,
-                relative_threshold=relative_threshold,
+                pssm, threshold=threshold, relative_threshold=relative_threshold
             )
             for pssm in motifs_list
         ]

--- a/dnachisel/SequencePattern/MotifPssmPattern.py
+++ b/dnachisel/SequencePattern/MotifPssmPattern.py
@@ -1,7 +1,5 @@
-import Bio
 from Bio.Seq import Seq
 from Bio import motifs
-from Bio.Align.AlignInfo import PSSM
 from .SequencePattern import SequencePattern
 import numpy as np
 
@@ -31,7 +29,7 @@ class MotifPssmPattern(SequencePattern):
     """
 
     def __init__(self, pssm, threshold=None, relative_threshold=None):
-        if not isinstance(pssm, Bio.motifs.Motif):
+        if not isinstance(pssm, motifs.Motif):
             raise ValueError(
                 f"Expected PSSM type of `Bio.motifs.Motif`, but {type(pssm)} was passed"
             )

--- a/dnachisel/SequencePattern/MotifPssmPattern.py
+++ b/dnachisel/SequencePattern/MotifPssmPattern.py
@@ -1,3 +1,4 @@
+import Bio
 from Bio.Seq import Seq
 from Bio import motifs
 from Bio.Align.AlignInfo import PSSM
@@ -30,7 +31,10 @@ class MotifPssmPattern(SequencePattern):
     """
 
     def __init__(
-        self, pssm, threshold=None, relative_threshold=None,
+        self,
+        pssm,
+        threshold=None,
+        relative_threshold=None,
     ):
         if not isinstance(pssm, Bio.motifs.Motif):
             raise ValueError(
@@ -70,7 +74,9 @@ class MotifPssmPattern(SequencePattern):
         #     sequence, threshold=self.threshold, both=False
         # )
         indices = find_pssm_matches_with_numpy(
-            pssm_matrix=self.pssm_matrix, sequence=sequence, threshold=self.threshold,
+            pssm_matrix=self.pssm_matrix,
+            sequence=sequence,
+            threshold=self.threshold,
         )
         return [(i, i + self.size, 1) for i in indices]
 
@@ -115,7 +121,9 @@ class MotifPssmPattern(SequencePattern):
         motif.name = name
         pssm = motif
         return MotifPssmPattern(
-            pssm=pssm, threshold=threshold, relative_threshold=relative_threshold,
+            pssm=pssm,
+            threshold=threshold,
+            relative_threshold=relative_threshold,
         )
 
     @classmethod
@@ -164,7 +172,9 @@ class MotifPssmPattern(SequencePattern):
 
         return [
             MotifPssmPattern(
-                pssm, threshold=threshold, relative_threshold=relative_threshold,
+                pssm,
+                threshold=threshold,
+                relative_threshold=relative_threshold,
             )
             for pssm in motifs_list
         ]


### PR DESCRIPTION
Current tests in the `dev` branch fail because of a missing `Bio` import. This fixes it (replaces `Bio.motif` by `motif`). My formater also touched a few extra lines (removing commas).

I also removed the unused PSSM import.